### PR TITLE
fix: Use an RTL-friendly method for hiding sr-only text

### DIFF
--- a/ariaNotify-polyfill.js
+++ b/ariaNotify-polyfill.js
@@ -177,7 +177,11 @@ if (!("ariaNotify" in Element.prototype)) {
       this.ariaLive = "polite";
       this.ariaAtomic = "true";
       this.style.position = "absolute";
-      this.style.left = "-9999px";
+      this.style.width = "1px";
+      this.style.height = "1px";
+      this.style.overflow = "hidden";
+      this.style.clipPath = "rect(0 0 0 0)";
+      this.style.overflowWrap = "normal";
     }
 
     /**


### PR DESCRIPTION
I tested this locally in Safari on `ariaNotify-polyfill/examples/suggested-text/index.html` to ensure the text is not visible.