### PR TITLE
add -1px margin to live region element

### DIFF
--- a/ariaNotify-polyfill.js
+++ b/ariaNotify-polyfill.js
@@ -176,7 +176,8 @@ if (!("ariaNotify" in Element.prototype)) {
     connectedCallback() {
       this.ariaLive = "polite";
       this.ariaAtomic = "true";
-      this.style.margin = "-1px";
+      this.style.marginLeft = "-1px";
+      this.style.marginTop = "-1px";
       this.style.position = "absolute";
       this.style.width = "1px";
       this.style.height = "1px";

--- a/ariaNotify-polyfill.js
+++ b/ariaNotify-polyfill.js
@@ -176,6 +176,7 @@ if (!("ariaNotify" in Element.prototype)) {
     connectedCallback() {
       this.ariaLive = "polite";
       this.ariaAtomic = "true";
+      this.style.margin = "-1px";
       this.style.position = "absolute";
       this.style.width = "1px";
       this.style.height = "1px";


### PR DESCRIPTION
In #2 we fixed some style issues which were causing a scroll issue on dotcom. The fix worked mostly, but is missing a `margin: -1px;`. Without that the region adds a 1px height to the layout and as a consequence we still have a very small scrollbar on full page layouts. This resolves that.