### PR TITLE
fix: Set 'repository.url' in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "@github/arianotify-polyfill",
   "version": "0.0.0-development",
   "description": "Polyfill for the ARIA Notification API",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/github/ariaNotify-polyfill.git"
+  },
   "keywords": [],
   "license": "MIT",
   "author": "GitHub Inc.",


### PR DESCRIPTION
The latest [“Publish to npm” workflow run](https://github.com/github/ariaNotify-polyfill/actions/runs/13503814665/job/37728589058) failed with:
> npm error code E422
> npm error 422 Unprocessable Entity - PUT https://registry.npmjs.org/@github%2farianotify-polyfill - Error verifying sigstore provenance bundle: Failed to validate repository information: package.json: "repository.url" is "", expected to match "https://github.com/github/ariaNotify-polyfill" from provenance

This PR sets `repository.url` to `"git+https://github.com/github/ariaNotify-polyfill.git"`, similar to what we use in other repos (where similar publish workflows work).

Notably, that’s different from `"https://github.com/github/ariaNotify-polyfill"`, the URL mentioned in the error message above—as a result, this PR may (or may not) fix the workflow error. If it doesn’t, then updating the value to `"https://github.com/github/ariaNotify-polyfill"` is the obvious next step.