### PR TITLE
Ensure live region is appended to `role="dialog"`

### DIFF
--- a/ariaNotify-polyfill.js
+++ b/ariaNotify-polyfill.js
@@ -73,7 +73,7 @@ if (!("ariaNotify" in Element.prototype)) {
 
       // Get root element
       let root = /** @type {Element} */ (
-        this.element.closest("dialog") || this.element.getRootNode()
+        this.element.closest("dialog") || this.element.closest("[role='dialog']") || this.element.getRootNode()
       );
       if (!root || root instanceof Document) root = document.body;
 


### PR DESCRIPTION
Fixes: https://github.com/github/ariaNotify-polyfill/issues/13

It'd be nice to add tests for dialog scenarios we use ariaNotify in covering `<dialog>` and `[role="dialog"]`. It doesn't look like there are any right now - it looks a bit involved, so I will not tackle that in this PR. Filed: https://github.com/github/ariaNotify-polyfill/issues/14