### PR TITLE
feat: Implement on `Document`

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Polyfill for the [ARIA Notification API](https://github.com/WICG/accessible-notifications/blob/main/README.md)
 
-The goal of this library is to polyfill `ariaNotify` so that it can be used seamlessly across browsers that support the native functionality, and those that don't. This adds the `Element.prototype.ariaNotify` function if it does not exist, emulating the native functionality.
+The goal of this library is to polyfill `ariaNotify` so that it can be used seamlessly across browsers that support the native functionality, and those that don't. This adds the `Element.prototype.ariaNotify` and/or `Document.prototype.ariaNotify` functions if they do not exist, emulating the native functionality.
 
 This is used in production on github.com.
 

--- a/arianotify-polyfill.js
+++ b/arianotify-polyfill.js
@@ -1,6 +1,6 @@
 // @ts-check
 
-if (!("ariaNotify" in Element.prototype)) {
+if (!("ariaNotify" in Element.prototype) || !("ariaNotify" in Document.prototype)) {
   /** @type {string} */
   let uniqueId = `${Date.now()}`;
   try {
@@ -166,15 +166,31 @@ if (!("ariaNotify" in Element.prototype)) {
   }
   customElements.define(liveRegionCustomElementName, LiveRegionCustomElement);
 
-  /**
-   * @param {string} message
-   * @param {object} options
-   * @param {"high" | "normal"} [options.priority]
-   */
-  Element.prototype["ariaNotify"] = function (
-    message,
-    { priority = "normal" } = {}
-  ) {
-    queue.enqueue(new Message({ element: this, message, priority }));
-  };
+  if (!("ariaNotify" in Element.prototype)) {
+    /**
+     * @param {string} message
+     * @param {object} options
+     * @param {"high" | "normal"} [options.priority]
+     */
+    Element.prototype["ariaNotify"] = function (
+      message,
+      { priority = "normal" } = {}
+    ) {
+      queue.enqueue(new Message({ element: this, message, priority }));
+    };
+  }
+
+  if (!("ariaNotify" in Document.prototype)) {
+    /**
+     * @param {string} message
+     * @param {object} options
+     * @param {"high" | "normal"} [options.priority]
+     */
+    Document.prototype["ariaNotify"] = function (
+      message,
+      { priority = "normal" } = {}
+    ) {
+      queue.enqueue(new Message({ element: this.documentElement, message, priority }));
+    };
+  }
 }


### PR DESCRIPTION
Fixes #19 

From that issue:
> The `ariaNotify` explainer includes several [examples of calling `document.ariaNotify`](https://github.com/MicrosoftEdge/MSEdgeExplainers/blob/main/Accessibility/AriaNotify/explainer.md#example-1), so this should be supported by the polyfill. However, the polyfill only [implements `ariaNotify` on `Element`](https://github.com/github/ariaNotify-polyfill/blob/173af81ac1cbcfa1a28cb99589eb3761a8b05cb6/ariaNotify-polyfill.js#L174C3-L174C20) (`document instanceof Element` is `false`).

This PR implements `ariaNotify` on `Document`.