### PR TITLE
tests: Bypass native `ariaNotify` in polyfill tests

### DIFF
--- a/arianotify-polyfill.js
+++ b/arianotify-polyfill.js
@@ -3,14 +3,14 @@
 const domAPIsAreAvailable =
   typeof globalThis.Element !== "undefined" &&
   typeof globalThis.Document !== "undefined";
-const shouldForceAriaNotifyPolyfill =
-  /** @type {typeof globalThis & {__ariaNotifyPolyfillForce?: boolean}} */ (
+const shouldBypassNativeAriaNotify =
+  /** @type {typeof globalThis & {__bypassNativeAriaNotify?: boolean}} */ (
     globalThis
-  ).__ariaNotifyPolyfillForce === true;
+  ).__bypassNativeAriaNotify === true;
 
 if (
   domAPIsAreAvailable &&
-  (shouldForceAriaNotifyPolyfill ||
+  (shouldBypassNativeAriaNotify ||
     !("ariaNotify" in Element.prototype) ||
     !("ariaNotify" in Document.prototype))
 ) {
@@ -218,7 +218,7 @@ if (
     queue.enqueue(new Message({ element: this, message, priority }));
   };
 
-  if (shouldForceAriaNotifyPolyfill || !("ariaNotify" in Element.prototype)) {
+  if (shouldBypassNativeAriaNotify || !("ariaNotify" in Element.prototype)) {
     Object.defineProperty(Element.prototype, "ariaNotify", {
       configurable: true,
       writable: true,
@@ -238,7 +238,7 @@ if (
     queue.enqueue(new Message({ element: this.documentElement, message, priority }));
   };
 
-  if (shouldForceAriaNotifyPolyfill || !("ariaNotify" in Document.prototype)) {
+  if (shouldBypassNativeAriaNotify || !("ariaNotify" in Document.prototype)) {
     Object.defineProperty(Document.prototype, "ariaNotify", {
       configurable: true,
       writable: true,

--- a/arianotify-polyfill.js
+++ b/arianotify-polyfill.js
@@ -3,10 +3,16 @@
 const domAPIsAreAvailable =
   typeof globalThis.Element !== "undefined" &&
   typeof globalThis.Document !== "undefined";
+const shouldForceAriaNotifyPolyfill =
+  /** @type {typeof globalThis & {__ariaNotifyPolyfillForce?: boolean}} */ (
+    globalThis
+  ).__ariaNotifyPolyfillForce === true;
 
 if (
   domAPIsAreAvailable &&
-  (!("ariaNotify" in Element.prototype) || !("ariaNotify" in Document.prototype))
+  (shouldForceAriaNotifyPolyfill ||
+    !("ariaNotify" in Element.prototype) ||
+    !("ariaNotify" in Document.prototype))
 ) {
   /** @type {string} */
   let uniqueId = `${Date.now()}`;
@@ -200,31 +206,43 @@ if (
     AssertiveLiveRegionCustomElement
   );
 
-  if (!("ariaNotify" in Element.prototype)) {
-    /**
-     * @param {string} message
-     * @param {object} options
-     * @param {"high" | "normal"} [options.priority]
-     */
-    Element.prototype["ariaNotify"] = function (
-      message,
-      { priority = "normal" } = {}
-    ) {
-      queue.enqueue(new Message({ element: this, message, priority }));
-    };
+  /**
+   * @param {string} message
+   * @param {object} options
+   * @param {"high" | "normal"} [options.priority]
+   */
+  const elementAriaNotify = function (
+    message,
+    { priority = "normal" } = {}
+  ) {
+    queue.enqueue(new Message({ element: this, message, priority }));
+  };
+
+  if (shouldForceAriaNotifyPolyfill || !("ariaNotify" in Element.prototype)) {
+    Object.defineProperty(Element.prototype, "ariaNotify", {
+      configurable: true,
+      writable: true,
+      value: elementAriaNotify,
+    });
   }
 
-  if (!("ariaNotify" in Document.prototype)) {
-    /**
-     * @param {string} message
-     * @param {object} options
-     * @param {"high" | "normal"} [options.priority]
-     */
-    Document.prototype["ariaNotify"] = function (
-      message,
-      { priority = "normal" } = {}
-    ) {
-      queue.enqueue(new Message({ element: this.documentElement, message, priority }));
-    };
+  /**
+   * @param {string} message
+   * @param {object} options
+   * @param {"high" | "normal"} [options.priority]
+   */
+  const documentAriaNotify = function (
+    message,
+    { priority = "normal" } = {}
+  ) {
+    queue.enqueue(new Message({ element: this.documentElement, message, priority }));
+  };
+
+  if (shouldForceAriaNotifyPolyfill || !("ariaNotify" in Document.prototype)) {
+    Object.defineProperty(Document.prototype, "ariaNotify", {
+      configurable: true,
+      writable: true,
+      value: documentAriaNotify,
+    });
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,8 +13,7 @@
         "@guidepup/guidepup": "^0.24.0",
         "@guidepup/playwright": "^0.15.0",
         "@playwright/test": "^1.48.0",
-        "@web/test-runner": "^0.20.1",
-        "@web/test-runner-playwright": "^0.11.1"
+        "@web/test-runner": "^0.20.1"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1078,21 +1077,6 @@
       "dev": true,
       "dependencies": {
         "@web/test-runner-core": "^0.13.0"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@web/test-runner-playwright": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/@web/test-runner-playwright/-/test-runner-playwright-0.11.1.tgz",
-      "integrity": "sha512-l9tmX0LtBqMaKAApS4WshpB87A/M8sOHZyfCobSGuYqnREgz5rqQpX314yx+4fwHXLLTa5N64mTrawsYkLjliw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@web/test-runner-core": "^0.13.0",
-        "@web/test-runner-coverage-v8": "^0.8.0",
-        "playwright": "^1.53.0"
       },
       "engines": {
         "node": ">=18.0.0"

--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
   },
   "files": [],
   "scripts": {
-    "test": "npx playwright install firefox && web-test-runner",
-    "test:guidepup": "npx playwright install firefox && npx playwright test"
+    "test": "web-test-runner",
+    "test:guidepup": "npx playwright test"
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4-fix.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "@guidepup/guidepup": "^0.24.0",
     "@guidepup/playwright": "^0.15.0",
     "@playwright/test": "^1.48.0",
-    "@web/test-runner": "^0.20.1",
-    "@web/test-runner-playwright": "^0.11.1"
+    "@web/test-runner": "^0.20.1"
   }
 }

--- a/playwright.config.mjs
+++ b/playwright.config.mjs
@@ -9,10 +9,10 @@ const config = {
   retries: 0,
   projects: [
     {
-      name: "Microsoft Edge",
+      name: "Google Chrome",
       use: {
-        ...devices["Desktop Edge"],
-        channel: "msedge",
+        ...devices["Desktop Chrome"],
+        channel: "chrome",
       },
     },
   ],

--- a/playwright.config.mjs
+++ b/playwright.config.mjs
@@ -9,8 +9,11 @@ const config = {
   retries: 0,
   projects: [
     {
-      name: 'firefox', // Use Firefox because Firefox doesn’t have a native implementation of 'ariaNotify' (as of 2026-01-15), so we can test the polyfill in it.
-      use: devices['Desktop Firefox'],
+      name: "Microsoft Edge",
+      use: {
+        ...devices["Desktop Edge"],
+        channel: "msedge",
+      },
     },
   ],
   quiet: false,

--- a/tests/bypass-native-arianotify.js
+++ b/tests/bypass-native-arianotify.js
@@ -10,6 +10,6 @@ for (const prototype of [Element.prototype, Document.prototype]) {
   });
 }
 
-/** @type {typeof globalThis & {__ariaNotifyPolyfillForce?: boolean}} */ (
+/** @type {typeof globalThis & {__bypassNativeAriaNotify?: boolean}} */ (
   globalThis
-).__ariaNotifyPolyfillForce = true;
+).__bypassNativeAriaNotify = true;

--- a/tests/force-arianotify-polyfill.js
+++ b/tests/force-arianotify-polyfill.js
@@ -1,0 +1,15 @@
+// @ts-check
+
+for (const prototype of [Element.prototype, Document.prototype]) {
+  Object.defineProperty(prototype, "ariaNotify", {
+    configurable: true,
+    writable: true,
+    value() {
+      throw new Error("Expected tests to use the ariaNotify polyfill");
+    },
+  });
+}
+
+/** @type {typeof globalThis & {__ariaNotifyPolyfillForce?: boolean}} */ (
+  globalThis
+).__ariaNotifyPolyfillForce = true;

--- a/tests/guidepup/nvda.spec.mjs
+++ b/tests/guidepup/nvda.spec.mjs
@@ -25,6 +25,13 @@ import path from "node:path";
 
 const test = baseTest.extend({
   context: async ({ context }, run) => {
+    await context.addInitScript({
+      path: path.join(
+        import.meta.dirname,
+        "..",
+        "force-arianotify-polyfill.js"
+      ),
+    });
     await context.route("**/*", (route, request) =>
       route.fulfill({
         path: path.join(

--- a/tests/guidepup/nvda.spec.mjs
+++ b/tests/guidepup/nvda.spec.mjs
@@ -29,7 +29,7 @@ const test = baseTest.extend({
       path: path.join(
         import.meta.dirname,
         "..",
-        "force-arianotify-polyfill.js"
+        "bypass-native-arianotify.js"
       ),
     });
     await context.route("**/*", (route, request) =>

--- a/tests/guidepup/voiceover.spec.mjs
+++ b/tests/guidepup/voiceover.spec.mjs
@@ -13,7 +13,7 @@ const test = baseTest.extend({
       path: path.join(
         import.meta.dirname,
         "..",
-        "force-arianotify-polyfill.js"
+        "bypass-native-arianotify.js"
       ),
     });
     await context.route("**/*", (route, request) =>

--- a/tests/guidepup/voiceover.spec.mjs
+++ b/tests/guidepup/voiceover.spec.mjs
@@ -9,6 +9,13 @@ import path from "node:path";
 
 const test = baseTest.extend({
   context: async ({ context }, run) => {
+    await context.addInitScript({
+      path: path.join(
+        import.meta.dirname,
+        "..",
+        "force-arianotify-polyfill.js"
+      ),
+    });
     await context.route("**/*", (route, request) =>
       route.fulfill({
         path: path.join(

--- a/tests/web-test-runner/arianotify-polyfill.js
+++ b/tests/web-test-runner/arianotify-polyfill.js
@@ -1,1 +1,0 @@
-../../arianotify-polyfill.js

--- a/web-test-runner.config.js
+++ b/web-test-runner.config.js
@@ -6,8 +6,8 @@ export default {
   nodeResolve: true,
   browsers: [
     playwrightLauncher({
-      product: 'firefox', // Use Firefox instead of Chrome (web-test-runner’s default), because Firefox doesn’t have a native implementation of 'ariaNotify' (as of 2025-11-07), so we can test the polyfill in it.
-      launchOptions: { headless: true }
+      product: 'chromium',
+      launchOptions: { channel: "msedge", headless: true }
     }),
   ],
   plugins: [
@@ -18,6 +18,7 @@ export default {
           return context.body.replace(
             /<\/body>/,
             `
+  <script src="./tests/force-arianotify-polyfill.js"></script>
   <script src="./arianotify-polyfill.js"></script>
   <script type="module">
     import { runTests } from "@web/test-runner-mocha";

--- a/web-test-runner.config.js
+++ b/web-test-runner.config.js
@@ -18,7 +18,7 @@ export default {
           return context.body.replace(
             /<\/body>/,
             `
-  <script src="./tests/force-arianotify-polyfill.js"></script>
+  <script src="./tests/bypass-native-arianotify.js"></script>
   <script src="./arianotify-polyfill.js"></script>
   <script type="module">
     import { runTests } from "@web/test-runner-mocha";

--- a/web-test-runner.config.js
+++ b/web-test-runner.config.js
@@ -18,8 +18,8 @@ export default {
           return context.body.replace(
             /<\/body>/,
             `
-  <script src="./tests/bypass-native-arianotify.js"></script>
-  <script src="./arianotify-polyfill.js"></script>
+  <script src="/tests/bypass-native-arianotify.js"></script>
+  <script src="/arianotify-polyfill.js"></script>
   <script type="module">
     import { runTests } from "@web/test-runner-mocha";
     import { tests } from "./arianotify-polyfill.test.js";

--- a/web-test-runner.config.js
+++ b/web-test-runner.config.js
@@ -1,15 +1,7 @@
-import { playwrightLauncher } from '@web/test-runner-playwright';
-
 export default {
   files: "tests/web-test-runner/*.test.html",
   coverage: true,
   nodeResolve: true,
-  browsers: [
-    playwrightLauncher({
-      product: 'chromium',
-      launchOptions: { channel: "msedge", headless: true }
-    }),
-  ],
   plugins: [
     {
       name: "include-polyfill",


### PR DESCRIPTION
### Problem

Native support for `ariaNotify` shipped in Firefox 150.0: https://www.firefox.com/en-US/firefox/150.0/releasenotes/. As a result, our existing tests—running in Firefox—no longer test the polyfill itself.

### Solution

- Support loading the `ariaNotify` polyfill even in browsers with native `ariaNotify` support, to enable polyfill testing (both Web Test Runner and Guidepup).
- Use Chrome for browser-backed tests because it is [preinstalled on GitHub Actions runners](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md#browsers-and-drivers) and Web Test Runner’s default. This reduces configuration, browser installation time, and failure points.